### PR TITLE
Updated pod.yml with new secrets configuration for aws

### DIFF
--- a/pod.yml
+++ b/pod.yml
@@ -10,13 +10,15 @@ spec:
     command: ["sleep"]
     args: ["infinity"]
     env:
-      - name: AWS_PROFILE
-        value: "prp"
       - name: AWS_S3_ENDPOINT
-        value: "https://s3.nautilus.optiputer.net"
+        value: "http://rook-ceph-rgw-rooks3.rook"
     volumeMounts:
-      - mountPath: /root/.aws
-        name: credentials
+      - name: "prp-s3-credentials"
+        mountPath: "/root/.aws/credentials"
+        subPath: "credentials"
+      - name: "prp-s3-credentials"
+        mountPath: "/root/.s3cfg"
+        subPath: ".s3cfg"
     resources:
       requests:
         cpu: "1"
@@ -26,6 +28,6 @@ spec:
         memory: "2Gi"
   restartPolicy: Never
   volumes:
-    - name: credentials
+    - name: prp-s3-credentials
       secret:
-        secretName: $USER-aws-credentials
+        secretName: prp-s3-credentials


### PR DESCRIPTION
I've added 2 files under the k8s secrets named `prp-s3-credentials`, `/root/.aws/credentials` and `/root/.s3cfg` (for s3cmd, which I summarily declare trounces awscli for usability).

I've updated the pod.yml example here as follows:
 - The `volumeMounts` now mount only the file, not the entire folder (the mount is read-only, so that's useful).
 - I absolutely positively cannot find a way to make `awscli` respect a non AWS endpoint without a complex install of the endpoint plugin which was beyond what we should be doing in the secrets file. See: https://github.com/aws/aws-cli/issues/1270. So I just configured nautilus S3 as default and removed profile. Note: If someone needs to access AWS s3 they will need to modify these files anyway which they can't because they're read only under secrets, so some other solution will be necessary anyway.
 - Updated the endpoint in the k8s cluster to the high speed internal endpoint.
 - Added the `.s3cfg` config for `s3cmd` which contains the credentials as well. The `prp-s3-credentials` secret contains two files now.
 - Tested both `awscli` and `s3cmd` work in a pod as seen below.

```
root@davidparks21-pod:/app# aws --endpoint $AWS_S3_ENDPOINT s3 ls s3://braingeneers/
                           PRE archive/
                           PRE fashion-mnist/
                           PRE mea/
                           PRE nrezaee/
                           PRE rcurrie/
                           PRE simulated/
root@davidparks21-pod:/app# s3cmd ls s3://braingeneers/
                       DIR   s3://braingeneers/archive/
                       DIR   s3://braingeneers/fashion-mnist/
                       DIR   s3://braingeneers/mea/
                       DIR   s3://braingeneers/nrezaee/
                       DIR   s3://braingeneers/rcurrie/
                       DIR   s3://braingeneers/simulated/
```

